### PR TITLE
Bug Fix: Dark Mode Campatablity with input's placeholder and Extra Space creating useless scrolling are solved

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -135,3 +135,10 @@ body {
   border-color: white;
   color: white;
 }
+.dark-mode ::placeholder {
+  color: white;
+  opacity: 1; /* Firefox */
+}
+.dark-mode ::-ms-input-placeholder { /* Edge 12 -18 */
+  color: white;
+}

--- a/popup.html
+++ b/popup.html
@@ -36,7 +36,7 @@
       </nav>
 
       <!-- Notes List -->
-      <div id="notes-list" class="mb-3"></div>
+      <div id="notes-list" class=""></div>
 
       <!-- Note Input -->
       <textarea


### PR DESCRIPTION
# Bugs and Issues
The current I Notes extension may have some styling issues like
- When the user creates a lot of notes, the note body adds an extra scrollbar
- When the user switches to dark mode, the textarea placeholder text remains invisible

## Solved
- I have solved the extra scrollbar problem by removing the `<div id="notes-list" class=""></div>` mb-3 class
The mb-3 class was producing useless spacing causing the body to make an extra scrollbar
- I have solved the textarea placeholder compatibility problem with dark mode, I have added some CSS that will add dark mode to every placeholder in the extension